### PR TITLE
Add guix install method to README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -44,6 +44,14 @@ However, `pass` does a lot of things to assure the robustness and security of pa
   ```
   pip install --user cpass
   ```
+  
+ ## Install with GNU Guix
+
+The [guixrus channel](https://git.sr.ht/~whereiseveryone/guixrus) also provides cpass.
+
+After [adding guixrus](https://git.sr.ht/~whereiseveryone/guixrus#permanent) to your [channels.scm](https://guix.gnu.org/manual/en/html_node/Using-a-Custom-Guix-Channel.html) run the following:
+
+`guix install cpass-guixrus`
 
 - Clone the repo or download the single script file.
 

--- a/Readme.md
+++ b/Readme.md
@@ -45,13 +45,15 @@ However, `pass` does a lot of things to assure the robustness and security of pa
   pip install --user cpass
   ```
   
- ## Install with GNU Guix
+- Install with GNU Guix
 
-The [guixrus channel](https://git.sr.ht/~whereiseveryone/guixrus) also provides cpass.
+  The [guixrus channel](https://git.sr.ht/~whereiseveryone/guixrus) also provides cpass.
 
-After [adding guixrus](https://git.sr.ht/~whereiseveryone/guixrus#permanent) to your [channels.scm](https://guix.gnu.org/manual/en/html_node/Using-a-Custom-Guix-Channel.html) run the following:
+  After [adding guixrus](https://git.sr.ht/~whereiseveryone/guixrus#permanent) to your [channels.scm](https://guix.gnu.org/manual/en/html_node/Using-a-Custom-Guix-Channel.html) run the following:
 
-`guix install cpass-guixrus`
+  ```
+  guix install cpass-guixrus
+  ```
 
 - Clone the repo or download the single script file.
 


### PR DESCRIPTION
Hi,

This commit adds an alternative installation method with GNU Guix package manager from the [GuixRUS](https://git.sr.ht/~whereiseveryone/guixrus) channel.

I packaged cpass [0.9.3](https://git.sr.ht/~whereiseveryone/guixrus/commit/33f317fc177a7a75ec1609900da8f9da70ed219d) (I had also packaged [0.9.2](https://git.sr.ht/~whereiseveryone/guixrus/commit/be25d88c74e42d15a022ece85d6f125426b803c7) in a previous commit) for guix and put it in a pre-release channel called [GuixRUS](https://git.sr.ht/~whereiseveryone/guixrus/commit/389dc1db8379d59d50041284b7fe3f59a28f9c23) that I maintain with some other [Guix](guix.gnu.org) upstream contributors.

All commits are gpg signed by the [maintainers](https://meta.sr.ht/~whereiseveryone.pgp).