### PR TITLE
Update cpass GuixRUs package name and README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -47,12 +47,13 @@ However, `pass` does a lot of things to assure the robustness and security of pa
   
 - Install with GNU Guix
 
-  The [guixrus channel](https://git.sr.ht/~whereiseveryone/guixrus) also provides cpass.
+  The [GuixRUs](https://git.sr.ht/~whereiseveryone/guixrus) channel also provides `cpass`.
 
-  After [adding guixrus](https://git.sr.ht/~whereiseveryone/guixrus#permanent) to your [channels.scm](https://guix.gnu.org/manual/en/html_node/Using-a-Custom-Guix-Channel.html) run the following:
+  After [adding](https://git.sr.ht/~whereiseveryone/guixrus#subscribing) `GuixRUs` to your [channels.scm](https://guix.gnu.org/manual/en/html_node/Using-a-Custom-Guix-Channel.html), run the following two commands:
 
   ```
-  guix install cpass-guixrus
+  guix pull
+  guix install cpass
   ```
 
 - Clone the repo or download the single script file.


### PR DESCRIPTION
Hi,

Just updating the [GuixRUS](https://git.sr.ht/~whereiseveryone/guixrus) package name for cpass in the README.

We changed the package name from `cpass-guixrus` to `cpass` since we are not sending cpass to upstream until after the `1.0.0` release and we probably won't get any variable name clashes.

There's a few little minor details I updated also such as running `guix pull` after adding to `channels.scm` to sync the channel.

`guix pull` is like `apt-get update`

Thanks!